### PR TITLE
fix: output files are removed on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-babel",
   "description": "Transform TypeScript compiler result using Babel to granular target control",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "license": "MIT",
   "author": "Vladimir Krivosheev",
   "bin": {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -63,8 +63,7 @@ transpile(async (basePath: string, config: ts.ParsedCommandLine, tsConfig: any) 
 
 async function removeOld(outDir: string, emittedFiles: Set<string>): Promise<any> {
   await BluebirdPromise.map(await readdir(outDir), file => {
-    // ts uses / regardless of OS
-    const fullPath = `${outDir}/${file}`
+    const fullPath = path.resolve(outDir, file)
     if (!file.includes(".")) {
       return removeOld(fullPath, emittedFiles)
     }


### PR DESCRIPTION
In the last commit you updated the `file` to use path.resolve. `fullPath` was not updated and therefore mismatches in the `!emittedFiles.has(fullPath)` check. As a result, the remove condition was always true and all output files were removed.

Ex.
`file`: `C:\Users\Asus\Desktop\electron-builder\test\out\linux\linuxArchiveTest.js`
`fullPath`: `C:\Users\Asus\Desktop\electron-builder\test\out/linux/linuxArchiveTest.js`

Mismatch existed for all processed files. This PR fixes it.